### PR TITLE
[POL-1132] Change the default limit of signable templates

### DIFF
--- a/lib/signable/concerns/query.rb
+++ b/lib/signable/concerns/query.rb
@@ -34,7 +34,7 @@ module Signable
       end
 
       module ClassMethods
-        def all(offset = 0, limit = 10)
+        def all(offset = 0, limit = 30)
           response = client.all(entry_point, offset, limit)
 
           if response.ok?

--- a/lib/signable/concerns/query.rb
+++ b/lib/signable/concerns/query.rb
@@ -34,7 +34,7 @@ module Signable
       end
 
       module ClassMethods
-        def all(offset = 0, limit = 30)
+        def all(offset: 0, limit: 30)
           response = client.all(entry_point, offset, limit)
 
           if response.ok?

--- a/lib/signable/version.rb
+++ b/lib/signable/version.rb
@@ -1,3 +1,3 @@
 module Signable
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/spec/support/concerns/query.rb
+++ b/spec/support/concerns/query.rb
@@ -17,7 +17,7 @@ shared_examples 'Query' do
       end
     end
 
-    context "#when not persisted" do
+    context "when not persisted" do
       let(:described) { described_class.new }
 
       it "call client create" do
@@ -54,7 +54,7 @@ shared_examples 'Query' do
   end
 
   describe ".all" do
-    it "call client all with default value for offet and limit" do
+    it "call client all with default value for offset and limit" do
       expect(described_class.client).to receive(:all).with(described_class.entry_point, 0, 30).and_return response
       described_class.all
     end

--- a/spec/support/concerns/query.rb
+++ b/spec/support/concerns/query.rb
@@ -55,7 +55,7 @@ shared_examples 'Query' do
 
   describe ".all" do
     it "call client all with default value for offet and limit" do
-      expect(described_class.client).to receive(:all).with(described_class.entry_point, 0, 10).and_return response
+      expect(described_class.client).to receive(:all).with(described_class.entry_point, 0, 30).and_return response
       described_class.all
     end
   end


### PR DESCRIPTION
Extend the default limit of signable templates to 30. As part of this change we will change method to use keyword arguments.

Jira:
https://smartpension.atlassian.net/browse/POL-1132