### PR TITLE
[ROACH-2135] spec use rails to 7.2.1, ruby required >=3.1

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Ruby 2.7
+      - name: Set up Ruby 3.1.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.1.0
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install gems

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Ruby 3.1.0
+      - name: Set up Ruby 3.3.4
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.0
+          ruby-version: 3.3.4
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install gems

--- a/.github/workflows/signable-rspec.yml
+++ b/.github/workflows/signable-rspec.yml
@@ -9,10 +9,10 @@ jobs:
   run_test_suite:
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Ruby 2.7
+      - name: Set up Ruby 3.3.4
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 3.3.4
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run bundle install

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rspec
 AllCops:
+  TargetRubyVersion: 3.1
   DisplayCopNames: true
   StyleGuideCopsOnly: false
   NewCops: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2024-10-22
+
+Bumped dependencies versions (ruby >= 3.0, activesupport >= 7.0)
+
 ## [0.2.0] - 2022-03-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.3.0] - 2024-10-22
 
-Bumped dependencies versions (ruby >= 3.0, activesupport >= 7.0)
+Bumped dependencies versions (ruby >= 3.1, activesupport >= 7.0)
 
 ## [0.2.0] - 2022-03-07
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,5 @@
 
 source 'https://rubygems.org'
 
-ruby '>=2.7.0'
-
 # Specify your gem's dependencies in signable.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in signable.gemspec
 gemspec
+
+gem 'activesupport', '~> 7.2'

--- a/lib/signable/version.rb
+++ b/lib/signable/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Signable
-  VERSION = '0.2.0'
+  VERSION = '0.3.0'
 end

--- a/signable.gemspec
+++ b/signable.gemspec
@@ -19,17 +19,18 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.1.0'
 
-  spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'pry', '~> 0.12.2'
-  spec.add_development_dependency 'rake', '~> 12.3.3'
-  spec.add_development_dependency 'rspec', '~> 3.9'
-  spec.add_development_dependency 'rubocop', '~> 1.7.0'
-  spec.add_development_dependency 'rubocop-rspec', '~> 2.1.0'
+  spec.add_development_dependency 'bundler', '~> 2.5'
+  spec.add_development_dependency 'pry', '~> 0.14.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'rubocop', '~> 1.66'
+  spec.add_development_dependency 'rubocop-rspec', '~> 2.12'
   spec.add_development_dependency 'vcr', '~> 6.0'
   spec.add_development_dependency 'webmock', '~> 3.8.1'
+  spec.add_development_dependency 'activesupport', '~> 7.2.1.1'
 
-  spec.add_dependency 'activesupport', '> 4.2'
+  spec.add_dependency 'activesupport', '>= 7.0'
   spec.add_dependency 'httparty', '~> 0.13'
 end

--- a/signable.gemspec
+++ b/signable.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.1.0'
 
+  spec.add_development_dependency 'activesupport', '~> 7.2.1.1'
   spec.add_development_dependency 'bundler', '~> 2.5'
   spec.add_development_dependency 'pry', '~> 0.14.0'
   spec.add_development_dependency 'rake', '~> 13.0'
@@ -29,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop-rspec', '~> 2.12'
   spec.add_development_dependency 'vcr', '~> 6.0'
   spec.add_development_dependency 'webmock', '~> 3.8.1'
-  spec.add_development_dependency 'activesupport', '~> 7.2.1.1'
 
   spec.add_dependency 'activesupport', '>= 7.0'
   spec.add_dependency 'httparty', '~> 0.13'

--- a/signable.gemspec
+++ b/signable.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.1.0'
 
-  spec.add_development_dependency 'activesupport', '~> 7.2.1.1'
   spec.add_development_dependency 'bundler', '~> 2.5'
   spec.add_development_dependency 'pry', '~> 0.14.0'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
require ruby 3.1 or later; run specs on activesupport 7.2.1.1; bump gems dependencies

story: https://smartpension.atlassian.net/browse/ROACH-2135
epic: https://smartpension.atlassian.net/browse/ROACH-2084

https://www.ruby-lang.org/en/downloads/branches/